### PR TITLE
ci: add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "daily"
+      time: "07:30"
+      timezone: "Asia/Tokyo"
+  - package-ecosystem: "maven"
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "daily"
+      time: "07:30"
+      timezone: "Asia/Tokyo"
+  - package-ecosystem: "npm"
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "daily"
+      time: "07:30"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
Dependabotの設定ファイルを追加しました。

GitHub Actions、Maven、NPMの依存関係を毎日自動更新するようスケジュールを設定しました。

更新は日本時間の午前7時30分に行われます。

## 概要
<!-- 以下にissueを記載 (close #xxx)-->
close 

<!-- 以下にプルリクの内容を記載 -->
- 

### スクリーンショット
<!-- 以下にスクリーンショットを添付 -->
